### PR TITLE
Test building the site as part of PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,10 @@
 name: Deploy to github pages
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 
@@ -22,6 +26,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trigger the deployment workflow, up until just before the deploy step to make sure there aren't any syntax errors. Also enable manually triggering a test build of the site.